### PR TITLE
feat: add litellm AI gateway proxy

### DIFF
--- a/hosts/ix/container-litellm.nix
+++ b/hosts/ix/container-litellm.nix
@@ -1,0 +1,71 @@
+# LiteLLM AI Gateway — unified API proxy for 100+ LLM providers
+# Provides an OpenAI-compatible endpoint at port 4000.
+#
+# Both config.yaml and .env are managed as sops secrets (see secrets/ix.yaml):
+#   litellm_config  → /mnt/arrakis/litellm/config.yaml
+#   litellm_env     → /mnt/arrakis/litellm/.env
+#
+# References:
+#   https://docs.litellm.ai/docs/proxy/docker_quick_start
+#   https://github.com/BerriAI/litellm
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+
+let
+  cfg = config.homelab.litellm;
+  inherit (lib) mkEnableOption mkIf;
+in
+{
+  options.homelab.litellm = {
+    enable = mkEnableOption "LiteLLM AI Gateway proxy server";
+  };
+
+  config = mkIf cfg.enable {
+    # LiteLLM Proxy Container
+    virtualisation.oci-containers.containers."ix-litellm" = {
+      image = "ghcr.io/berriai/litellm:main-latest";
+      environmentFiles = [
+        "/mnt/arrakis/litellm/.env"
+      ];
+      volumes = [
+        "/mnt/arrakis/litellm/config.yaml:/app/config.yaml:ro,z"
+      ];
+      ports = [
+        "4000:4000/tcp"
+      ];
+      log-driver = "journald";
+      cmd = [
+        "--config"
+        "/app/config.yaml"
+        "--detailed_debug"
+      ];
+      extraOptions = [
+        "--network-alias=litellm"
+        "--network=ix_default"
+      ];
+    };
+
+    systemd.services."podman-ix-litellm" = {
+      serviceConfig = {
+        Restart = lib.mkOverride 90 "always";
+      };
+      unitConfig.RequiresMountsFor = "/mnt/arrakis";
+      after = [
+        "podman-network-ix_default.service"
+      ];
+      requires = [
+        "podman-network-ix_default.service"
+      ];
+      partOf = [
+        "podman-compose-ix-root.target"
+      ];
+      wantedBy = [
+        "podman-compose-ix-root.target"
+      ];
+    };
+  };
+}

--- a/hosts/ix/default.nix
+++ b/hosts/ix/default.nix
@@ -49,6 +49,7 @@
     ./container-overleaf.nix
     ./container-wallabag.nix
     ./container-immich.nix
+    ./container-litellm.nix
 
     # VMs
     ./vm-clawdbot.nix
@@ -78,6 +79,14 @@
         group = "muad";
         mode = "0600";
       };
+
+      litellm_config = {
+        path = "/mnt/arrakis/litellm/config.yaml";
+      };
+
+      litellm_env = {
+        path = "/mnt/arrakis/litellm/.env";
+      };
     };
   };
 
@@ -88,6 +97,8 @@
       hostName = "ix";
     };
   };
+
+  homelab.litellm.enable = true;
 
   # All ix_default containers depend on NFS mounts via their network service.
   systemd.services."podman-network-ix_default".unitConfig.RequiresMountsFor = "/mnt/arrakis /mnt/media /mnt/nextcloud";
@@ -119,8 +130,10 @@
       192.168.0.100 nhook.calvo.dev
       192.168.0.100 overleaf.calvo.dev
       192.168.0.100 vpn.calvo.dev
+      192.168.0.100 litellm.calvo.dev
     '';
     firewall.allowedTCPPorts = [
+      4000  # litellm AI gateway
       5000  # overleaf git bridge
       8765  # nhook webhook server
       18437 # fifoteca backend


### PR DESCRIPTION
## LiteLLM AI Gateway on ix

Adds LiteLLM as a Podman container on the `ix` host — an OpenAI-compatible
proxy that routes all LLM requests through a configurable provider endpoint.

### Changes

- **`hosts/ix/container-litellm.nix`** _(new)_ — Podman container definition
  using `ghcr.io/berriai/litellm:main-latest`, joins `ix_default` network,
  exposes port `4000`
- **`hosts/ix/default.nix`** — imports the module, enables via
  `homelab.litellm.enable`, opens port `4000` in the firewall, registers
  `litellm.calvo.dev` in extraHosts, and adds sops secret entries for
  `litellm_config` and `litellm_env`

### Post-deploy

After merging, the encrypted values for `litellm_config` and `litellm_env`
need to be added to `secrets/ix.yaml` on the target machine:

```bash
sops set secrets/ix.yaml 'litellm_config' < /tmp/config.yaml
sops set secrets/ix.yaml 'litellm_env' < /tmp/.env
```