### PR TITLE
feat: add PostgreSQL database to litellm proxy

### DIFF
--- a/hosts/ix/container-litellm.nix
+++ b/hosts/ix/container-litellm.nix
@@ -16,6 +16,32 @@
 }:
 
 {
+  ## DB Container
+  virtualisation.oci-containers.containers."litellm-db" = {
+    image = "postgres:17-alpine";
+    environmentFiles = [ "/mnt/arrakis/litellm/.env" ];
+    volumes = [ "/mnt/arrakis/litellm/database:/var/lib/postgresql/data" ];
+    log-driver = "journald";
+    extraOptions = [
+      "--health-cmd=pg_isready -U litellm"
+      "--health-interval=20s"
+      "--health-timeout=3s"
+      "--health-retries=5"
+      "--network-alias=litellm-db"
+      "--network=ix_default"
+    ];
+  };
+
+  systemd.services."podman-litellm-db" = {
+    serviceConfig.Restart = lib.mkOverride 90 "always";
+    unitConfig.RequiresMountsFor = "/mnt/arrakis";
+    after = [ "podman-network-ix_default.service" ];
+    requires = [ "podman-network-ix_default.service" ];
+    partOf = [ "podman-compose-ix-root.target" ];
+    wantedBy = [ "podman-compose-ix-root.target" ];
+  };
+
+  ## LiteLLM Proxy Container
   virtualisation.oci-containers.containers."litellm" = {
     image = "ghcr.io/berriai/litellm:main-latest";
     environmentFiles = [
@@ -23,6 +49,9 @@
     ];
     volumes = [
       "/mnt/arrakis/litellm/config.yaml:/app/config.yaml:ro,z"
+    ];
+    dependsOn = [
+      "litellm-db"
     ];
     ports = [
       "4000:4000/tcp"
@@ -46,6 +75,7 @@
     unitConfig.RequiresMountsFor = "/mnt/arrakis";
     after = [
       "podman-network-ix_default.service"
+      "podman-litellm-db.service"
     ];
     requires = [
       "podman-network-ix_default.service"


### PR DESCRIPTION
Adds PostgreSQL database (`litellm-db`) to the litellm container for:
- Admin UI at `http://ix:4000/ui`
- Virtual keys
- Spend tracking

### Changes
- **`hosts/ix/container-litellm.nix`** — adds `litellm-db` container (PostgreSQL 17 Alpine), `litellm` now depends on it

### Post-deploy
Add secrets to `secrets/ix.yaml` on the target machine:

```bash
sops set secrets/ix.yaml 'litellm_config' < /tmp/config.yaml
sops set secrets/ix.yaml 'litellm_env' < /tmp/.env
```

See `container-litellm.nix` comments for config templates.