### PR TITLE
feat(kaitain): expose litellm via SWAG reverse proxy

### DIFF
--- a/hosts/kaitain/container-swag.nix
+++ b/hosts/kaitain/container-swag.nix
@@ -14,7 +14,8 @@ let
     "cloud"       # nextcloud
     "bag"         # wallabag
     "overleaf"    # overleaf
-    "photos"       # immich
+    "photos"      # immich
+    "litellm"     # litellm AI gateway
   ];
   subdomains = lib.concatStringsSep ", " services;
   ixHost = "192.168.0.4";


### PR DESCRIPTION
Adds litellm subdomain to SWAG reverse proxy on kaitain, making the AI gateway accessible at `https://litellm.calvo.dev`.

### Changes
- **`hosts/kaitain/container-swag.nix`** — adds `litellm` to services list, creates proxy config pointing to `ix:4000`, mounts config into SWAG container

### After deploy
- Ensure `litellm.calvo.dev` DNS record points to kaitain public IP (Cloudflare)
- Verify SWAG picks up the new proxy config